### PR TITLE
Fix warnings for unsupported nodes within tables

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function _convert(node, warnings) {
 			return node.attrs.shortName;
 
 		case 'table':
-			return node.content.map(node => _convert(node)).join('');
+			return node.content.map(node => _convert(node, warnings)).join('');
 
 		case 'tableRow': {
 			let output = '|';
@@ -77,10 +77,10 @@ function _convert(node, warnings) {
 		}
 
 		case 'tableHeader':
-			return `${node.content.map(node => _convert(node)).join('')}|`;
+			return `${node.content.map(node => _convert(node, warnings)).join('')}|`;
 
 		case 'tableCell':
-			return `${node.content.map(node => _convert(node)).join('')}|`;
+			return `${node.content.map(node => _convert(node, warnings)).join('')}|`;
 
 		default:
 			console.log('adding warning for', node.type);


### PR DESCRIPTION
Currently converting adf with a `mediaSingle` or `panel` (or any other unsupported node type) within a table fails catastrophically.
The reason is that the `warnings` in such a case are `undefined`, and `add` is not defined on that...