### PR TITLE
Fix strikethrough conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function _convertMarks(node, warnings) {
 				break;
 
 			case 'strike':
-				converted = `~${converted}~`;
+				converted = `~~${converted}~~`;
 				break;
 
 			case 'strong':


### PR DESCRIPTION
This library currently converts strikethrough marks to:

```
~text~
```

But that is not correct. Converting this back to ADF using `@atlaskit/editor-markdown-transformer` creates subscript.

This PR fixes it so it correctly converts to:

```
~~text~~
```